### PR TITLE
Create go-ossf-slsa3-publish.yml

### DIFF
--- a/.github/workflows/go-ossf-slsa3-publish.yml
+++ b/.github/workflows/go-ossf-slsa3-publish.yml
@@ -1,0 +1,38 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# This workflow lets you compile your Go project using an SLSA3-compliant builder.
+# This workflow will generate a so-called "provenance" file describing the steps
+# that were performed to generate the final binary.
+# The project is an initiative of the OpenSSF (openssf.org) and is developed at
+# https://github.com/slsa-framework/slsa-github-generator.
+# The provenance file can be verified using https://github.com/slsa-framework/slsa-verifier.
+# For more information about SLSA and how it improves the supply chain, visit slsa.dev.
+
+name: SLSA Go releaser
+on:
+  workflow_dispatch:
+  release:
+    types: [created]
+
+permissions: read-all
+
+jobs:
+  # ========================================================================================================================================
+  #     Prerequisite: Create a .slsa-goreleaser in the root directory of your project.
+  #       See format in https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/go/README.md#configuration-file
+  #=========================================================================================================================================
+  build:
+    permissions:
+      id-token: write # To sign.
+      contents: write # To upload release assets.
+      actions: read   # To read workflow path.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v1.4.0
+    with:
+      go-version: 1.17
+      # =============================================================================================================
+      #     Optional: For more options, see https://github.com/slsa-framework/slsa-github-generator#golang-projects
+      # =============================================================================================================
+


### PR DESCRIPTION
.github/workflows/lint.yml.

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
Your changes add a TrustedRoot field to the AttestationVerifier struct and ensure it is passed into the NewVerifierOptions. This improves the ability to provide a trusted root for attestation verification, which is important for security and flexibility.

Diff summary:

Added TrustedRoot string to AttestationVerifier.
Passed TrustedRoot to NewVerifierOptions in VerifyAttestation.
Review points:

The code change is straightforward and non-breaking—existing code using AttestationVerifier will not be affected unless they want to use the new TrustedRoot field.
The new field is optional; if not set, the behavior should be unchanged for callers not using TrustedRoot.
Be sure to check that anywhere AttestationVerifier is instantiated, the new TrustedRoot field is set as needed, or is left with the default zero value as appropriate.
If there are tests covering attestation verification, consider adding or updating tests to cover cases where TrustedRoot is set.
Suggestions:

If this field is expected to be set from configuration or CLI, make sure the relevant wiring is in place.
If documentation exists for AttestationVerifier or its usage, update it to mention TrustedRoot.
Conclusion:
This is a clean and useful change. If you have tested or validated the new code path (with and without TrustedRoot), it's ready for merge pending any additional feedback from reviewers.

Would you like a suggested PR description or help reviewing other parts of this comparison?

